### PR TITLE
Organize Gemfile

### DIFF
--- a/.rubocop
+++ b/.rubocop
@@ -1,0 +1,14 @@
+inherit_gem:
+  rubocop-rails_config:
+    - config/rails.yml
+
+AllCops:
+  TargetRubyVersion: ~
+  TargetRailsVersion: 5.2
+  Exclude:
+    - '**/bin/**/*'
+    - '**/db/**/*'
+    - '**/tmp/**/*'
+    - '**/script/setup'
+    - '**/lib/tasks/**/*'
+    - '**/vendor/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -1,86 +1,102 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
+
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.1'
+ruby "2.5.1"
 
 # Framework
-gem 'rails', '~> 5.2.0'
+gem "rails", "~> 5.2.0"
 
 # Data
-gem 'pg'
+gem "pg"
+gem "storext"
+gem "with_advisory_lock"
+gem "will_paginate", "~> 3.1.0"
+gem "geokit-rails"
+gem "textacular", "~> 5.0" # Full-text search in Postgres
+
+# REST-API
+gem "active_model_serializers"
+# gem 'jbuilder', '~> 2.5'
 
 # Webserver
-gem 'puma'
-gem 'puma_worker_killer'
+gem "puma"
+gem "puma_worker_killer"
 
-# Misc
-gem 'sass-rails', '~> 5.0' # Use SCSS for stylesheets
-gem 'uglifier', '>= 1.3.0' # Use Uglifier as compressor for JavaScript assets
-gem 'figaro' # environment variables
-gem 'omniauth'
-gem 'omniauth-facebook'
-gem 'omniauth-twitter'
-gem 'omniauth-spotify'
-gem 'devise'
-gem 'jquery-rails'
-gem 'rspotify'
-gem 'sidekiq'
+# Frontend
+gem "sass-rails", "~> 5.0" # Use SCSS for stylesheets
+gem "uglifier", ">= 1.3.0" # Use Uglifier as compressor for JavaScript assets
+gem "jquery-rails"
+gem "coffee-rails", "~> 4.2"
+gem "turbolinks", "~> 5"
+gem "rails_admin", "~> 1.3"
+
+# User Authentication
+gem "devise"
+gem "omniauth"
+gem "omniauth-facebook"
+gem "omniauth-twitter"
+gem "omniauth-spotify"
+
+# Music Services
+gem "rspotify"
+gem "musicbrainz", github: "inkstak/musicbrainz", tag: "1.0.0"
+gem "lastfm"
+gem "songkickr"
+gem "feedjira"          # A feed fetching and parsing library
+gem "opengraph_parser"  # library for parsing Open Graph Protocol information from a website
+
+# Background Processing
+gem "sidekiq"
 gem "sidekiq-throttled"
 gem "sidekiq-cron"
-gem 'sidekiq-unique-jobs'
-gem 'storext'
-gem 'with_advisory_lock'
-gem 'sentry-raven'
-gem 'textacular', '~> 5.0'
-gem 'faker'
-gem 'musicbrainz', github: 'inkstak/musicbrainz', tag: '1.0.0'
-gem 'httparty'
-gem 'jwt'
-gem "feedjira"
-gem "opengraph_parser"
-gem 'dalli'
-gem 'memcachier'
-gem 'scout_apm'
-gem 'rails_admin', '~> 1.3'
-gem "intercom-rails"
-gem 'lastfm'
-gem 'songkickr'
-gem 'geokit-rails'
-gem "barnes"
-gem "active_model_serializers"
-gem 'will_paginate', '~> 3.1.0'
+gem "sidekiq-unique-jobs"
 
-# Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.2'
-# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
-gem 'jbuilder', '~> 2.5'
+# Stats/Error Reporting
+gem "barnes"            # report GC usage data to statsd
+gem "scout_apm"         # Monitors Ruby apps and reports detailed metrics on performance to Scout.
+gem "sentry-raven"      # report errors to Sentry
+
+# Caching
+gem "dalli"
+gem "memcachier"
+
+# Misc
+gem "figaro"            # environment variables
+gem "faker"
+gem "httparty"
+gem "jwt"
+gem "intercom-rails"    # customer relationship management and messaging tool
+gem "colorize"          # ability to colorize output strings
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.1.0', require: false
+gem "bootsnap", ">= 1.1.0", require: false
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
 end
 
 group :development do
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
-  gem 'listen', '>= 3.0.5', '< 3.2'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
+  gem "better_errors"
+  gem "binding_of_caller"
+  # gem "web-console", ">= 3.3.0"
+  gem "listen", ">= 3.0.5", "< 3.2"
+  gem "spring"
+  gem "spring-watcher-listen", "~> 2.0.0"
   gem "letter_opener"
+  gem "foreman", require: false
+  gem "bundleup", require: false
+  gem "rubocop", require: false
+  gem "rubocop-rspec", require: false
+  gem "rubocop-rails_config", require: false
 end
 
 group :test do
-  # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '>= 2.15', '< 4.0'
-  gem 'selenium-webdriver'
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  gem "capybara", ">= 2.15", "< 4.0"
+  gem "selenium-webdriver"
+  gem "chromedriver-helper"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    ast (2.4.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -71,10 +72,16 @@ GEM
       multi_json (~> 1)
       statsd-ruby (~> 1.1)
     bcrypt (3.1.12)
-    bindex (0.5.0)
+    better_errors (2.5.0)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
     builder (3.2.3)
+    bundleup (0.6.1)
     byebug (10.0.2)
     capybara (3.11.0)
       addressable
@@ -91,6 +98,7 @@ GEM
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     coffee-rails (4.2.2)
@@ -100,10 +108,12 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    colorize (0.8.1)
     concurrent-ruby (1.1.3)
     connection_pool (2.2.2)
     crass (1.0.4)
     dalli (2.7.9)
+    debug_inspector (0.0.3)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (4.5.0)
@@ -135,6 +145,8 @@ GEM
       thor (~> 0.14)
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
+    foreman (0.85.0)
+      thor (~> 0.19.1)
     fugit (1.1.6)
       et-orbi (~> 1.1, >= 1.1.6)
       raabro (~> 1.1)
@@ -160,9 +172,7 @@ GEM
     intercom-rails (0.4.0)
       activesupport (> 3.0)
     io-like (0.3.0)
-    jbuilder (2.8.0)
-      activesupport (>= 4.2.0)
-      multi_json (>= 1.2)
+    jaro_winkler (1.5.1)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -247,7 +257,11 @@ GEM
       addressable
       nokogiri
     orm_adapter (0.5.0)
+    parallel (1.12.1)
+    parser (2.5.3.0)
+      ast (~> 2.4.0)
     pg (1.1.3)
+    powerpack (0.1.2)
     public_suffix (3.0.3)
     puma (3.12.0)
     puma_worker_killer (0.1.0)
@@ -299,6 +313,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.0.0)
     rake (12.3.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -317,6 +332,20 @@ GEM
     rspotify (2.3.1)
       omniauth-oauth2 (~> 1.3.1)
       rest-client (~> 2.0.2)
+    rubocop (0.60.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.4.0)
+    rubocop-rails_config (0.2.6)
+      railties (>= 3.0)
+      rubocop (~> 0.56)
+    rubocop-rspec (1.30.1)
+      rubocop (>= 0.60.0)
+    ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
     sass (3.7.2)
@@ -373,7 +402,7 @@ GEM
     temple (0.8.0)
     textacular (5.1.0)
       activerecord (>= 5.0, < 6.0)
-    thor (0.20.3)
+    thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
     turbolinks (5.2.0)
@@ -386,18 +415,14 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    unicode-display_width (1.4.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    warden (1.2.7)
-      rack (>= 1.0)
-    web-console (3.7.0)
-      actionview (>= 5.0)
-      activemodel (>= 5.0)
-      bindex (>= 0.4.0)
-      railties (>= 5.0)
+    warden (1.2.8)
+      rack (>= 2.0.6)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -414,20 +439,24 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   barnes
+  better_errors
+  binding_of_caller
   bootsnap (>= 1.1.0)
+  bundleup
   byebug
   capybara (>= 2.15, < 4.0)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  colorize
   dalli
   devise
   faker
   feedjira
   figaro
+  foreman
   geokit-rails
   httparty
   intercom-rails
-  jbuilder (~> 2.5)
   jquery-rails
   jwt
   lastfm
@@ -446,6 +475,9 @@ DEPENDENCIES
   rails (~> 5.2.0)
   rails_admin (~> 1.3)
   rspotify
+  rubocop
+  rubocop-rails_config
+  rubocop-rspec
   sass-rails (~> 5.0)
   scout_apm
   selenium-webdriver
@@ -462,7 +494,6 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
-  web-console (>= 3.3.0)
   will_paginate (~> 3.1.0)
   with_advisory_lock
 
@@ -470,4 +501,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/config/initializers/spotify.rb
+++ b/config/initializers/spotify.rb
@@ -1,1 +1,5 @@
-RSpotify.authenticate(ENV['spotify_key'], ENV['spotify_secret'])
+if ENV['spotify_key'] || ENV['spotify_secret']
+	RSpotify.authenticate(ENV['spotify_key'], ENV['spotify_secret'])
+else
+	puts "! please add `spotify_key` and `spotify_secret` to your config/application.yml file to enable Spotify support".yellow
+end

--- a/db/migrate/20180830233028_drop_news_table.rb
+++ b/db/migrate/20180830233028_drop_news_table.rb
@@ -1,6 +1,6 @@
 class DropNewsTable < ActiveRecord::Migration[5.2]
   def up
-    drop_table :news
+  	execute 'drop table if exists news'
   end
 
   def down


### PR DESCRIPTION
- cleaned up the `misc` category and added other categories for gems
- added comments to gems whose use was not immediately apparent
- added `foreman` so you can run foreman on a clean system
- added `colorize` for color output in the console
- added `rubocop` for standardized code formatting
- added a check in `config/initializers/spotify.rb` so the app can create the db on a fresh install without spotify keys
- fixed a migration that did not run on a clean install
