### PR TITLE
Multiple Enhancements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem "with_advisory_lock"
 gem "will_paginate", "~> 3.1.0"
 gem "geokit-rails"
 gem "textacular", "~> 5.0" # Full-text search in Postgres
+gem "ar_lazy_preload"      # automagic preloading defeats most N+1 queries
+
 
 # REST-API
 gem "active_model_serializers"

--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,9 @@ gem "geokit-rails"
 gem "textacular", "~> 5.0" # Full-text search in Postgres
 gem "ar_lazy_preload"      # automagic preloading defeats most N+1 queries
 
-
 # REST-API
 gem "active_model_serializers"
-# gem 'jbuilder', '~> 2.5'
+gem 'jbuilder', '~> 2.5'
 
 # Webserver
 gem "puma"

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem "sidekiq"
 gem "sidekiq-throttled"
 gem "sidekiq-cron"
 gem "sidekiq-unique-jobs"
+gem "sidekiq-failures"
 
 # Stats/Error Reporting
 gem "barnes"            # report GC usage data to statsd

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,9 @@ GEM
       activesupport (> 3.0)
     io-like (0.3.0)
     jaro_winkler (1.5.1)
+    jbuilder (2.8.0)
+      activesupport (>= 4.2.0)
+      multi_json (>= 1.2)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -465,6 +468,7 @@ DEPENDENCIES
   geokit-rails
   httparty
   intercom-rails
+  jbuilder (~> 2.5)
   jquery-rails
   jwt
   lastfm

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
     annotate (2.7.4)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
+    ar_lazy_preload (0.2.2)
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
@@ -444,6 +445,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   annotate
+  ar_lazy_preload
   barnes
   better_errors
   binding_of_caller

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,6 +376,8 @@ GEM
     sidekiq-cron (1.0.4)
       fugit (~> 1.1)
       sidekiq (>= 4.2.1)
+    sidekiq-failures (1.0.0)
+      sidekiq (>= 4.0.0)
     sidekiq-throttled (0.9.0)
       concurrent-ruby
       redis-prescription
@@ -488,6 +490,7 @@ DEPENDENCIES
   sentry-raven
   sidekiq
   sidekiq-cron
+  sidekiq-failures
   sidekiq-throttled
   sidekiq-unique-jobs
   songkickr

--- a/app/jobs/build_album_spotify_job.rb
+++ b/app/jobs/build_album_spotify_job.rb
@@ -28,7 +28,7 @@ class BuildAlbumSpotifyJob
 
         image = album.images.first['url'] if album.images.present?
 
-        if new_album.release_date.blank? and album.try(:release_date)
+        if new_album.release_date.blank? and album&.release_date
           if album.release_date_precision == 'year'
             date = Date.strptime("#{album.release_date}-01-01", '%Y-%m-%d')
           elsif album.release_date_precision == 'month'

--- a/app/jobs/build_artist_applemusic_job.rb
+++ b/app/jobs/build_artist_applemusic_job.rb
@@ -1,7 +1,7 @@
 class BuildArtistApplemusicJob
   include Sidekiq::Worker
   include Sidekiq::Throttled::Worker
-  
+
   sidekiq_options :queue => :applemusic
 
   sidekiq_throttle({
@@ -10,6 +10,8 @@ class BuildArtistApplemusicJob
   })
 
   def perform(artist_id)
+    return unless ENV['apple_token']
+
     artist = Artist.find artist_id
 
     response = HTTParty.get('https://api.music.apple.com/v1/catalog/us/search', {
@@ -24,7 +26,7 @@ class BuildArtistApplemusicJob
       all_genres = artist.genres.to_set
       all_genres = all_genres.merge(am_genre)
 
-      artist.update_attributes(applemusic_id: response.parsed_response['results']['artists']['data'].first['id'], applemusic_last_updated_at: Time.now, genres: all_genres) 
+      artist.update_attributes(applemusic_id: response.parsed_response['results']['artists']['data'].first['id'], applemusic_last_updated_at: Time.now, genres: all_genres)
 
       BuildAlbumApplemusicJob.perform_async(artist_id)
     end

--- a/app/jobs/build_artist_imvdb_job.rb
+++ b/app/jobs/build_artist_imvdb_job.rb
@@ -10,6 +10,8 @@ class BuildArtistImvdbJob
   })
 
   def perform(artist_id)
+    return unless ENV['imvdb_key']
+
     artist = Artist.find artist_id
     page = 1
     loop do
@@ -40,13 +42,11 @@ class BuildArtistImvdbJob
               release_date = Date.today-1.year
             end
 
-            music_video = MusicVideo.where('artist_id = ? AND source_data = ?', artist.id, source_data).first_or_create(
-                artist_id: artist.id, 
+            music_video = MusicVideo.where(artist: artist, source_data: source_data).first_or_create(
                 name: video['song_title'],
                 release_date: release_date,
                 image: video['image']['o'],
-                source: source['source'],
-                source_data: source_data)
+                source: source['source'])
           end
         end
       end

--- a/app/jobs/build_artist_lastfm_job.rb
+++ b/app/jobs/build_artist_lastfm_job.rb
@@ -12,6 +12,8 @@ class BuildArtistLastfmJob
   })
 
   def perform(artist_id)
+    return unless ENV['lastfm_key']
+
     artist = Artist.find artist_id
 
     lastfm = Lastfm.new(ENV['lastfm_key'], ENV['lastfm_secret'])
@@ -20,7 +22,7 @@ class BuildArtistLastfmJob
       lastfm_artist = lastfm.artist.get_info(artist:artist.name)
     rescue Lastfm::ApiError => e
     end
-    
+
     if lastfm_artist.present?
 
       if lastfm_artist['tags'].present?
@@ -42,7 +44,7 @@ class BuildArtistLastfmJob
       artist.lastfm_stats_playcount = lastfm_artist['stats']['playcount'].to_i
       artist.lastfm_bio = lastfm_artist['bio']['content']
       artist.lastfm_last_updated_at = Time.now
-      
+
       artist.save
     end
   end

--- a/app/jobs/build_artist_musicbrainz_job.rb
+++ b/app/jobs/build_artist_musicbrainz_job.rb
@@ -22,18 +22,20 @@ class BuildArtistMusicbrainzJob
 
       urls = musicbrainz_full_artist.urls
       external_homepage = urls.select{|key| key == 'official homepage'}['official homepage']
-      external_twitter = Array.wrap(urls['social network']).select{|key| key.include?("twitter")}.try(:first) if urls['social network'].present?
-      external_facebook = Array.wrap(urls['social network']).select{|key| key.include?("facebook")}.try(:first) if urls['social network'].present?
-      external_instagram = Array.wrap(urls['social network']).select{|key| key.include?("instagram")}.try(:first) if urls['social network'].present?
+      if urls['social network'].present?
+        external_twitter = Array.wrap(urls['social network']).select{|key| key.include?("twitter")}&.first
+        external_facebook = Array.wrap(urls['social network']).select{|key| key.include?("facebook")}&.first
+        external_instagram = Array.wrap(urls['social network']).select{|key| key.include?("instagram")}&.first
+      end
       external_wikipedia = urls['wikipedia']
-      external_youtube = Array.wrap(urls['youtube']).try(:first)
+      external_youtube = Array.wrap(urls['youtube'])&.first
 
       artist.update_attributes(
-        year_started: musicbrainz_artist.date_begin, 
-        year_ended: musicbrainz_artist.try(:date_end),
-        external_homepage: external_homepage, 
-        external_twitter: external_twitter, 
-        external_facebook: external_facebook, 
+        year_started: musicbrainz_artist.date_begin,
+        year_ended: musicbrainz_artist&.date_end,
+        external_homepage: external_homepage,
+        external_twitter: external_twitter,
+        external_facebook: external_facebook,
         external_instagram: external_instagram,
         external_wikipedia: external_wikipedia,
         external_youtube: external_youtube,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,10 @@ class User < ApplicationRecord
 
   has_many :connections
 
+  def email_required?
+    false
+  end
+
   def is_admin?
     admin
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@
 #  avatar                     :string
 #  current_sign_in_at         :datetime
 #  current_sign_in_ip         :inet
-#  email                      :string           default(""), not null
+#  email                      :citext           default("")
 #  encrypted_password         :string           default(""), not null
 #  last_sign_in_at            :datetime
 #  last_sign_in_ip            :inet

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,7 +47,7 @@ class User < ApplicationRecord
   has_many :albums, through: :artists
   has_many :music_videos, through: :artists
   has_many :streams
-  
+
   include Storext.model
   store_attributes :settings do
     show_compilations Boolean, default: false
@@ -71,7 +71,7 @@ class User < ApplicationRecord
   end
 
   def to_param
-    [id, screename.parameterize].join("-")
+    @to_param ||= [id, screename.parameterize].join("-")
   end
 
   def screename
@@ -124,7 +124,7 @@ class User < ApplicationRecord
       UserMailer.with(user: user).welcome_email.deliver_now
     end
 
-    user    
+    user
   end
 
   protected

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,6 +1,6 @@
 <p>Hello <%= @email %>!</p>
 
-<% if @resource.try(:unconfirmed_email?) %>
+<% if @resource&.unconfirmed_email? %>
   <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
 <% else %>
   <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,7 +19,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 20 } %>
 
 development:
   <<: *default

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+if ENV['twitter_key'].nil? && ENV['twitter_secret'].nil?
+  puts "! Twitter key/secret missing, won't be able to log into the app"
+end
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
@@ -9,7 +13,7 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   config.secret_key = 'b9c575ff8740a70bef511c391d5f8604b2456c016db584c32e6321feb12534c619c77739c3c14ee4bc2dc031712f49f6f08f4c0126214ec95eddd885b8320580'
-  
+
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
   # config.parent_controller = 'DeviseController'

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -9,7 +9,7 @@ RailsAdmin.config do |config|
   config.current_user_method(&:current_user)
 
   config.authorize_with do
-    redirect_to main_app.root_path unless current_user.is_admin?
+    redirect_to main_app.root_path unless current_user.admin?
   end
 
   ## == Cancan ==

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
+require 'sidekiq_unique_jobs/web'
+require 'sidekiq/cron/web'
+
 Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   # get "/sitemap.xml" => "pages#sitemap", :format => "xml", :as => :sitemap
@@ -6,11 +9,11 @@ Rails.application.routes.draw do
   # get "/sitemap-musicvideos.xml" => "pages#sitemap_musicvideos", :format => "xml", :as => :sitemap_musicvideos
   # get "/sitemap-pages.xml" => "pages#sitemap_pages", :format => "xml", :as => :sitemap_pages
   get 'pages/index'
-  
-  require 'sidekiq_unique_jobs/web'
-  require 'sidekiq/cron/web'
-  mount Sidekiq::Web => '/sidekiq'
-  
+
+  authenticate :user, lambda { |u| u.admin? } do
+    mount Sidekiq::Web => '/sidekiq'
+  end
+
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks', registrations: 'registrations' }
 
   authenticated :user do
@@ -70,7 +73,7 @@ Rails.application.routes.draw do
   end
 
   resources :events
-  
+
   get '/test' => 'pages#test'
   get '/token' => 'pages#token'
   root "pages#index"

--- a/db/migrate/20181116174940_change_null_restriction_on_users_email.rb
+++ b/db/migrate/20181116174940_change_null_restriction_on_users_email.rb
@@ -1,0 +1,11 @@
+class ChangeNullRestrictionOnUsersEmail < ActiveRecord::Migration[5.2]
+  def up
+    enable_extension('citext')
+    change_column :users, :email, :citext, null: true
+  end
+
+  def down
+    change_column :users, :email, :string, null: false
+    disable_extension('citext')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_11_201904) do
+ActiveRecord::Schema.define(version: 2018_11_16_174940) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "plpgsql"
 
   create_table "albums", force: :cascade do |t|
@@ -172,7 +173,7 @@ ActiveRecord::Schema.define(version: 2018_09_11_201904) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
+    t.citext "email", default: ""
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -10,7 +10,7 @@
 #  avatar                     :string
 #  current_sign_in_at         :datetime
 #  current_sign_in_ip         :inet
-#  email                      :string           default(""), not null
+#  email                      :citext           default("")
 #  encrypted_password         :string           default(""), not null
 #  last_sign_in_at            :datetime
 #  last_sign_in_ip            :inet

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -10,7 +10,7 @@
 #  avatar                     :string
 #  current_sign_in_at         :datetime
 #  current_sign_in_ip         :inet
-#  email                      :string           default(""), not null
+#  email                      :citext           default("")
 #  encrypted_password         :string           default(""), not null
 #  last_sign_in_at            :datetime
 #  last_sign_in_ip            :inet


### PR DESCRIPTION
- allow users without an email address to create accounts (because twitter doesn't require an email)
   - use `citext` type for `user.email` because `citext` is "case-insensitive" by nature (and free)
- increase dev db pool size because sidekiq couldn't run with just 5
- don't run jobs for 3rd party APIs that we don't have keys for
- prefer `&.` over `try()` because `&.` is built-into ruby itself... `try()` is a Rails method
- print a warning in the dev console if twitter keys are absent, you won't be able to log in
- add `sidekiq-failures` for managing the sidekiq job failures in production

and last, but not least...
- stop the sidekiq dashboard from being publicly available 
  - you now have to be an `admin` user