### PR TITLE
show only 1 artist per name

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -3,17 +3,14 @@ class ArtistsController < ApplicationController
 
   def index
     @user = current_user
-
-    @artists = Artist.followed_by(@user).with_name.order(name: :asc).limit(30)
+    @artists = Artist.select('DISTINCT ON ("artists"."name") *').followed_by(@user).with_name.order(name: :asc).limit(30)
 
     respond_with @artists
   end
 
   def show
     @user = current_user
-
-    @artist = Artist.where(id: params[:id]).first
-
+    @artist = Artist.find(params[:id])
     @albums = @artist.albums.order(release_date: :desc).types_for_user(@user)
     @music_videos = @artist.music_videos.order(release_date: :desc)
 


### PR DESCRIPTION
apparently, there are multiple artists records with the same name (looks like 1 per music service).  Which can currently be seen in the Artists tab of people you follow.

adding `SELECT DISTINCT ON ("artists"."name") *` to query to only show 1 per unique name.
