### PR TITLE
Normalize the config keys, use all lower case

### DIFF
--- a/app/models/apple_music.rb
+++ b/app/models/apple_music.rb
@@ -1,8 +1,8 @@
 class AppleMusic
   def self.token
-    return unless ENV['APPLE_PRIVATE_KEY']
-    
-    private_key = ENV['APPLE_PRIVATE_KEY']
+    return unless ENV['apple_private_key']
+
+    private_key = ENV['apple_private_key']
 
     keyId = ENV['apple_app_key']
     teamId = ENV['apple_team_key']

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -1,9 +1,13 @@
 # Details for setting these up can be found in the README: https://github.com/DroptuneHQ/droptune#how-to-start
-twitter_key: KEY
-twitter_secret: KEY
-spotify_key: KEY
-spotify_secret: KEY
-apple_private_key: KEY
-apple_app_key: KEY
-apple_team_key: KEY
-imvdb_key: KEY
+
+# twitter_key: KEY
+# twitter_secret: KEY
+# spotify_key: KEY
+# spotify_secret: KEY
+# apple_private_key: |
+#  -----BEGIN PRIVATE KEY-----
+#  PRIVATE_KEY_CONTENTS HERE
+#  -----END PRIVATE KEY-----
+# apple_app_key: KEY
+# apple_team_key: KEY
+# imvdb_key: KEY


### PR DESCRIPTION
The `APPLE_PRIVATE_KEY` ENV key is currently being used, but the application.yml.sample defines it as all lower-case. Since the rest of the ENV keys are all lower case, follow suit.

This is a breaking change.

+ Add an example of how a private key is set